### PR TITLE
Fix Water Fog on NVIDIA GPUs

### DIFF
--- a/shaders/include/atmospherics/fog.glsl
+++ b/shaders/include/atmospherics/fog.glsl
@@ -368,7 +368,7 @@ vec3 waterExtinctionCoefficients = saturate(waterScatteringCoefficients + waterA
 
         for (uint i = 0u; i < WATER_FOG_STEPS; i++, worldPosition += worldIncrement, shadowPosition += shadowIncrement) {
             // Early exit if transmittance is too low
-            if (maxOf(transmittanceOut) < EPS) break;
+            if (maxOf(transmittance) < EPS) break;
 
             vec3 shadowScreenPosition = shadowClipToShadowScreen(shadowPosition);
 


### PR DESCRIPTION
Fixes a small bug where an unassigned variable value was being checked to optimise water fog.